### PR TITLE
fix issue with supplying arguments to genLambda

### DIFF
--- a/R/helperFunctions.R
+++ b/R/helperFunctions.R
@@ -43,8 +43,8 @@
 #' \item `loadings`: defines the primary loadings for each factor in a list structure, e. g. `loadings = list(c(.5, .4, .6), c(.8, .6, .6, .4))` defines a two factor model with three indicators loading on the first factor by .5, , 4., and .6, and four indicators loading in the second factor by .8, .6, .6, and .4.  
 #' \item `nIndicator`: used in conjunction with `loadM` or `loadMinmax`, defines the number of indicators by factor, e. g., `nIndicator = c(3, 4)` defines a two factor model with three and four indicators for the first and second factor, respectively. `nIndicator` can also be a single number to define the same number of indicators for each factor. 
 #' \item `loadM`: defines the mean loading either for all indicators (if a single number is provided) or separately for each factor (if a vector is provided), e. g. `loadM = c(.5, .6)` defines the mean loadings of the first factor to equal .5 and those of the second factor do equal .6
-#' \item `loadSd`: used in conjunction with `loadM`, defines the standard deviations of the loadings. If omitted or NULL, the standard deviations are zero. Otherwise, the loadings are sampled from a normal distribution with N(loadM, loadSD) for each factor. 
-#' \item `loadMinMax`: defines the minimum and maximum loading either for all factors or separately for each factor (as a list). The loadings are then sampled from a uniform. For example, `loadMinMax = list(c(.4, .6), c(.4, .8))` defines the loadings for the first factor lying between .4 and .6, and those for the second factor between .4 and .8. 
+#' \item `loadSD`: used in conjunction with `loadM`, defines the standard deviations of the loadings. If omitted or NULL, the standard deviations are zero. Otherwise, the loadings are sampled from a normal distribution with N(loadM, loadSD) for each factor. 
+#' \item `loadMinMax`: defines the minimum and maximum loading either for all factors or separately for each factor (as a list). The loadings are then sampled from a uniform distribution. For example, `loadMinMax = list(c(.4, .6), c(.4, .8))` defines the loadings for the first factor lying between .4 and .6, and those for the second factor between .4 and .8. 
 #' }      
 #'  
 #' @examples
@@ -132,8 +132,8 @@ semPower.genSigma <- function(Lambda = NULL,
   args <- list(...)
   
   if(is.null(Lambda)){
-    Lambda <- genLambda(args$loadings, args$nIndicator, 
-                        args$loadM, args$loadSD, args$loadMinMax) 
+    Lambda <- genLambda(args[['loadings']], args[['nIndicator']], 
+                        args[['loadM']], args[['loadSD']], args[['loadMinMax']]) 
   }
 
   nfac <- ncol(Lambda)


### PR DESCRIPTION
When extracting objects from a list using the $ operator, R does not seem to match all characters of the name of the object.

For example:
args <- list(nIndicator = rep(3,4), loadMinMax = c(.5, .6))
args$loadM
[1] 0.5 0.6 # extracts loadMinMax because the first characters are the same

args[['loadM']]
NULL # this works 

This issue caused problems with input validation in genLambda
if(!is.null(loadMinMax) && (!is.null(loadM) || !is.null(loadSD))) stop('Either specify mean and SD of loadings or specify min-max loading, both not both.')